### PR TITLE
docs: remove go::docs-check reference

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -51,10 +51,9 @@ Go code should be formatted by [`gofumpt`][gofumpt] and linted using
 [`golangci-lint`][golangci-lint]. This style is enforced by CI.
 
 ```bash
-just go::fmt-check    # Check formatting
-just go::fmt          # Auto-fix formatting
-just go::vet          # Run linter
-just go::docs-check   # Check generated docs are up to date
+just go::fmt-check   # Check formatting
+just go::fmt         # Auto-fix formatting
+just go::vet         # Run linter
 ```
 
 ### Documentation


### PR DESCRIPTION
## Summary

Remove `go::docs-check` from the Go code style section in development.md.
gomarkdoc was removed — API docs are on pkg.go.dev now.

🤖 Generated with [Claude Code](https://claude.ai/code)