### PR TITLE
style(logger): use multi-line function signatures

### DIFF
--- a/pkg/server/logger.go
+++ b/pkg/server/logger.go
@@ -36,31 +36,49 @@ type SlogWrapper struct {
 }
 
 // Noticef logs a formatted notice message.
-func (l *SlogWrapper) Noticef(format string, v ...interface{}) {
+func (l *SlogWrapper) Noticef(
+	format string,
+	v ...interface{},
+) {
 	l.logger.Info(fmt.Sprintf(format, v...))
 }
 
 // Warnf logs a formatted warning message.
-func (l *SlogWrapper) Warnf(format string, v ...interface{}) {
+func (l *SlogWrapper) Warnf(
+	format string,
+	v ...interface{},
+) {
 	l.logger.Warn(fmt.Sprintf(format, v...))
 }
 
 // Fatalf logs a formatted fatal error message.
-func (l *SlogWrapper) Fatalf(format string, v ...interface{}) {
+func (l *SlogWrapper) Fatalf(
+	format string,
+	v ...interface{},
+) {
 	l.logger.Error(fmt.Sprintf(format, v...))
 }
 
 // Errorf logs a formatted error message.
-func (l *SlogWrapper) Errorf(format string, v ...interface{}) {
+func (l *SlogWrapper) Errorf(
+	format string,
+	v ...interface{},
+) {
 	l.logger.Error(fmt.Sprintf(format, v...))
 }
 
 // Debugf logs a formatted debug message.
-func (l *SlogWrapper) Debugf(format string, v ...interface{}) {
+func (l *SlogWrapper) Debugf(
+	format string,
+	v ...interface{},
+) {
 	l.logger.Debug(fmt.Sprintf(format, v...))
 }
 
 // Tracef logs a formatted trace message (NATS requires this for tracing).
-func (l *SlogWrapper) Tracef(format string, v ...interface{}) {
+func (l *SlogWrapper) Tracef(
+	format string,
+	v ...interface{},
+) {
 	l.logger.Debug(fmt.Sprintf(format, v...)) // Map Trace to Debug in slog
 }


### PR DESCRIPTION
## Summary

- Apply project's mandatory multi-line function signature format to all six `SlogWrapper` methods in `logger.go`
- These were the only functions in the codebase not following the convention

## Test plan

- [x] `go test ./pkg/server/...` passes
- [x] No functional changes — formatting only

🤖 Generated with [Claude Code](https://claude.ai/code)