### PR TITLE
chore: add .github/repos.json for gh-reposync

### DIFF
--- a/.github/repos.json
+++ b/.github/repos.json
@@ -1,0 +1,38 @@
+{
+  "org": "osapi-io",
+  "settings": {
+    "has_issues": true,
+    "has_wiki": false,
+    "has_projects": false,
+    "delete_branch_on_merge": true,
+    "allow_merge_commit": false,
+    "allow_squash_merge": true,
+    "allow_rebase_merge": true,
+    "allow_auto_merge": true,
+    "web_commit_signoff_required": false
+  },
+  "security": {
+    "vulnerability_alerts": true,
+    "dependabot_security_updates": true,
+    "secret_scanning": true,
+    "secret_scanning_push_protection": true
+  },
+  "branch_protection": {
+    "branch": "main",
+    "enforce_admins": true,
+    "required_status_checks": { "strict": true },
+    "required_pull_request_reviews": { "required_approving_review_count": 0 },
+    "required_conversation_resolution": true,
+    "allow_force_pushes": false,
+    "allow_deletions": false,
+    "block_creations": true,
+    "restrictions": { "users": ["retr0h"], "teams": [], "apps": [] }
+  },
+  "repos": [
+    {
+      "name": "nats-server",
+      "description": "A Go package for running an embedded NATS server.",
+      "topics": ["golang", "messaging", "nats-jetstream", "nats-server", "osapi"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add per-repo `.github/repos.json` manifest for the [gh-reposync](https://github.com/retr0h/gh-reposync) extension
- Replaces the org-wide manifest that previously lived in `osapi/github/repos.json`
- Declares repo settings, security posture, branch protection, description, and topics

## Test plan
- [x] `gh reposync --check` reports no drift
- [x] `gh reposync --apply` brings any drift in line

🤖 Generated with [Claude Code](https://claude.ai/code)