### PR TITLE
chore: standardize LICENSE, AI policy, and code of conduct

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,6 +1,6 @@
 # AI Usage Policy
 
-The nats-server project has strict rules for AI usage:
+The osapi-io project has strict rules for AI usage:
 
 - **All AI usage in any form must be disclosed.** You must state
   the tool you used (e.g. Claude Code, Cursor, Amp) along with
@@ -30,13 +30,13 @@ The nats-server project has strict rules for AI usage:
   if you're interested in that then don't use AI, and we'll help you.
   I'm sorry that bad AI drivers have ruined this for you.
 
-These rules apply only to outside contributions to nats-server. Maintainers
+These rules apply only to outside contributions to osapi-io. Maintainers
 are exempt from these rules and may use AI tools at their discretion;
 they've proven themselves trustworthy to apply good judgment.
 
 ## There are Humans Here
 
-Please remember that nats-server is maintained by humans.
+Please remember that osapi-io is maintained by humans.
 
 Every discussion, issue, and pull request is read and reviewed by
 humans (and sometimes machines, too). It is a boundary point at which
@@ -52,7 +52,7 @@ strict rules to protect maintainers.
 
 ## AI is Welcome Here
 
-nats-server is written with plenty of AI assistance, and many maintainers
+osapi-io is written with plenty of AI assistance, and many maintainers
 embrace AI tools as a productive tool in their workflow. As a project,
 we welcome AI as a tool!
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-.
+john@dewey.ws.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the


### PR DESCRIPTION
## Summary

Standardizes `LICENSE`, `AI_POLICY.md`, and `CODE_OF_CONDUCT.md` against the
rest of the organization, as required by `repo-standards` in
[osapi-io/specs](https://github.com/osapi-io/specs).

These state organization-wide policy, so a repository holding a variant states
policy that is not the organization's.

## What was wrong org-wide

```
LICENSE      four copyright lines:  2026 OSAPI · 2025 John Dewey ·
                                    2024 John Dewey · 2026 John Dewey
AI_POLICY    substituted the repository name, and used OSAPI — which is
             also a repository, so it read as that product rather than
             the organization
CODE_OF_CONDUCT   missing from three repositories; enforcement contact
                  blank in the rest
```

## What this changes

- `AI_POLICY.md` and `CODE_OF_CONDUCT.md` are now byte-identical with every
  other repository, naming `osapi-io` and carrying a working enforcement
  contact.
- `LICENSE` keeps **this repository's creation year** and standardizes only the
  holder and the text. The year is deliberately not normalized — it records
  when the repository was created, and is never expressed as a range.

Part of the boilerplate sweep, done as one pass so per-repository conversion
work stays scoped to that repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)