### PR TITLE
chore: adopt go library standards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .coverage/
+.worktrees/
 dist/
 .just/
 .nats/jetstream/

--- a/justfile
+++ b/justfile
@@ -29,9 +29,13 @@ deps:
 test:
     just go::test
 
+# Generate code
+generate:
+    just go::generate
+
 # Format and lint before committing
 ready:
-    just go::generate
+    just generate
     just just::fmt
     just docs::fmt
     just go::fmt


### PR DESCRIPTION
## Summary

Adopts `go-library-standards` from
[osapi-io/specs](https://github.com/osapi-io/specs).

Small, mechanical changes so all four Go libraries carry the same configuration
where the specification requires it.

## Verified across all four libraries

```
codecov.yml · .golangci.yml · .mise.toml · labeler.yml
delete-merged-branch-config.yml · AI_POLICY.md · CODE_OF_CONDUCT.md
                                          all IDENTICAL

.golangci.yml   nats-client adds exclude-dirs: ./client — a directory
                exclusion, which the specification permits as specific
                to a library's package layout

lockfiles       no library ignores one
recipe surface  deps · test · generate · ready present in all four
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)