### PR TITLE
refactor: consume the flat go module

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -8,12 +8,12 @@
 #
 # The threshold absorbs rounding, not regression. With precision 2 and round
 # down, a change in statement count can render a genuine 100% as 99.99% and fail
-# the status on an artifact. `just go::unit-cov-check` is the exact check; this
+# the status on an artifact. `just go-unit-cov-check` is the exact check; this
 # tolerance exists so Codecov's own rounding does not report a failure the
 # coverage does not have.
 #
 # There is deliberately no `ignore:` list. Exclusions are defined once in
-# .coverignore and applied by `just go::unit-cov` before the profile is
+# .coverignore and applied by `just go-unit-cov` before the profile is
 # uploaded, so excluded files never reach Codecov. A second list here would be
 # free to drift from that one.
 coverage:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,9 +65,9 @@ Go code should be formatted by [gofumpt] and linted using [golangci-lint].
 This style is enforced by CI.
 
 ```bash
-just go::fmt-check   # Check formatting
-just go::fmt         # Auto-fix formatting
-just go::vet         # Run linter
+just go-fmt-check   # Check formatting
+just go-fmt         # Auto-fix formatting
+just go-vet         # Run linter
 ```
 
 golangci-lint runs errcheck, errname, goimports, govet, prealloc, predeclared,
@@ -109,8 +109,8 @@ just docs::fmt         # Auto-fix formatting
 
 ```bash
 just test           # Run all tests (lint + unit + coverage)
-just go::unit       # Run unit tests only
-just go::unit-cov   # Generate coverage report
+just go-unit       # Run unit tests only
+just go-unit-cov   # Generate coverage report
 go test -run TestName -v ./pkg/server/...  # Run a single test
 ```
 
@@ -118,7 +118,7 @@ Coverage is gated at 100%. `just test` fails if total coverage drops below it,
 so a change that adds untested code fails locally and in CI:
 
 ```bash
-just go::unit-cov-check   # Report coverage and fail below the target
+just go-unit-cov-check   # Report coverage and fail below the target
 ```
 
 The target is declared in `.github/codecov.yml` and in the shared `go` justfile

--- a/justfile
+++ b/justfile
@@ -11,7 +11,7 @@ mod? just '.just/remote/just.mod.just'
 # Fetch shared justfiles from osapi-justfiles
 fetch:
     mkdir -p .just/remote
-    curl -sSfL https://raw.githubusercontent.com/osapi-io/osapi-justfiles/refs/heads/    curl -sSfL https://raw.githubusercontent.com/osapi-io/osapi-justfiles/refs/heads/main/go/go.just -o .just/remote/go.just
+    curl -sSfL https://raw.githubusercontent.com/osapi-io/osapi-justfiles/refs/heads/main/go/go.just -o .just/remote/go.just
     curl -sSfL https://raw.githubusercontent.com/osapi-io/osapi-justfiles/refs/heads/main/docs.mod.just -o .just/remote/docs.mod.just
     curl -sSfL https://raw.githubusercontent.com/osapi-io/osapi-justfiles/refs/heads/main/docs.just -o .just/remote/docs.just
     curl -sSfL https://raw.githubusercontent.com/osapi-io/osapi-justfiles/refs/heads/main/just.mod.just -o .just/remote/just.mod.just

--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@
 # Recipes below use `just` subcommands instead of dependency syntax because just
 
 # validates dependencies at parse time, which would fail when modules aren't loaded.
-mod? go '.just/remote/go.mod.just'
+import? '.just/remote/go.just'
 mod? docs '.just/remote/docs.mod.just'
 mod? just '.just/remote/just.mod.just'
 
@@ -11,8 +11,7 @@ mod? just '.just/remote/just.mod.just'
 # Fetch shared justfiles from osapi-justfiles
 fetch:
     mkdir -p .just/remote
-    curl -sSfL https://raw.githubusercontent.com/osapi-io/osapi-justfiles/refs/heads/main/go.mod.just -o .just/remote/go.mod.just
-    curl -sSfL https://raw.githubusercontent.com/osapi-io/osapi-justfiles/refs/heads/main/go.just -o .just/remote/go.just
+    curl -sSfL https://raw.githubusercontent.com/osapi-io/osapi-justfiles/refs/heads/    curl -sSfL https://raw.githubusercontent.com/osapi-io/osapi-justfiles/refs/heads/main/go/go.just -o .just/remote/go.just
     curl -sSfL https://raw.githubusercontent.com/osapi-io/osapi-justfiles/refs/heads/main/docs.mod.just -o .just/remote/docs.mod.just
     curl -sSfL https://raw.githubusercontent.com/osapi-io/osapi-justfiles/refs/heads/main/docs.just -o .just/remote/docs.just
     curl -sSfL https://raw.githubusercontent.com/osapi-io/osapi-justfiles/refs/heads/main/just.mod.just -o .just/remote/just.mod.just
@@ -22,21 +21,21 @@ fetch:
 
 # Install all dependencies
 deps:
-    just go::deps
+    just go-deps
     go get -tool github.com/golang/mock/mockgen
 
 # Run all tests
 test:
-    just go::test
+    just go-test
 
 # Generate code
 generate:
-    just go::generate
+    just go-generate
 
 # Format and lint before committing
 ready:
     just generate
     just just::fmt
     just docs::fmt
-    just go::fmt
-    just go::vet
+    just go-fmt
+    just go-vet


### PR DESCRIPTION
Renames `go::<name>` call sites to `go-<name>` and imports `go/go.just` instead of loading `go.mod.just`.

Applies `converge-justfile-consumption` task 1.2. **Depends on [osapi-justfiles#46](https://github.com/osapi-io/osapi-justfiles/pull/46)** — `fetch` pulls `go/go.just` from `main`.

Verified against the flat module: `just go-unit-cov-check` reports coverage 100.0% meets target 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)