### PR TITLE
refactor: consume the flat just module

### DIFF
--- a/.github/workflows/just-lint.yml
+++ b/.github/workflows/just-lint.yml
@@ -17,4 +17,4 @@ jobs:
       - name: Fetch justfiles
         run: just fetch
       - name: Lint justfiles
-        run: just just::fmt-check
+        run: just just-fmt-check

--- a/justfile
+++ b/justfile
@@ -6,7 +6,7 @@ set allow-duplicate-variables
 # validates dependencies at parse time, which would fail when modules aren't loaded.
 import? '.just/remote/go.just'
 import? '.just/remote/md.just'
-mod? just '.just/remote/just.mod.just'
+import? '.just/remote/just.just'
 
 # No documentation site, so md formats every markdown file in the repository.
 md_site_dir := ""
@@ -18,8 +18,7 @@ fetch:
     mkdir -p .just/remote
     curl -sSfL https://raw.githubusercontent.com/osapi-io/osapi-justfiles/refs/heads/main/go/go.just -o .just/remote/go.just
     curl -sSfL https://raw.githubusercontent.com/osapi-io/osapi-justfiles/refs/heads/main/md/md.just -o .just/remote/md.just
-    curl -sSfL https://raw.githubusercontent.com/osapi-io/osapi-justfiles/refs/heads/main/just.mod.just -o .just/remote/just.mod.just
-    curl -sSfL https://raw.githubusercontent.com/osapi-io/osapi-justfiles/refs/heads/main/just.just -o .just/remote/just.just
+    curl -sSfL https://raw.githubusercontent.com/osapi-io/osapi-justfiles/refs/heads/main/just/just.just -o .just/remote/just.just
 
 # --- Top-level orchestration ---
 
@@ -39,7 +38,7 @@ generate:
 # Format and lint before committing
 ready:
     just generate
-    just just::fmt
+    just just-fmt
     just md-fmt
     just go-fmt
     just go-vet


### PR DESCRIPTION
Applies `converge-justfile-consumption` task 2.x.

`just.mod.just` is removed upstream and recipes rename from `just::fmt` to `just-fmt`. This imports `just/just.just` instead.

**Depends on [osapi-justfiles#57](https://github.com/osapi-io/osapi-justfiles/pull/57)** — `fetch` pulls `just/just.just` from `main`, so this fails until that merges.

This is the last module conversion. After it, no repository loads a `.mod.just` shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)