### PR TITLE
chore: label the kinds of file this repository holds

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,20 +1,26 @@
 ---
-github/action:
+kind/action:
   - changed-files:
       - any-glob-to-any-file: ".github/**/*.yml"
 
 kind/docs:
   - changed-files:
       - any-glob-to-any-file: "docs/**"
+      - any-glob-to-any-file: "**/*.md"
 
 kind/go:
   - changed-files:
       - any-glob-to-any-file: "**/*.go"
 
+kind/just:
+  - changed-files:
+      - any-glob-to-any-file: "**/justfile"
+      - any-glob-to-any-file: "**/*.just"
+
 kind/yaml:
   - changed-files:
-      - any-glob-to-any-file: "**/*.yaml"
-      - any-glob-to-any-file: "**/*.yml"
+      - any-glob-to-any-file: ["**/*.yaml", "**/*.yml"]
+        all-globs-to-all-files: "!.github/**"
 
 test/unit:
   - changed-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,10 +3,27 @@ kind/action:
   - changed-files:
       - any-glob-to-any-file: ".github/**/*.yml"
 
+kind/agents:
+  - changed-files:
+      - any-glob-to-any-file: "AGENTS.md"
+      - any-glob-to-any-file: "CLAUDE.md"
+      - any-glob-to-any-file: ".claude/**"
+
+kind/contributing:
+  - changed-files:
+      - any-glob-to-any-file: "CONTRIBUTING.md"
+
+kind/deps:
+  - changed-files:
+      - any-glob-to-any-file: "**/go.mod"
+      - any-glob-to-any-file: "**/go.sum"
+      - any-glob-to-any-file: "**/package.json"
+      - any-glob-to-any-file: "**/bun.lock"
+
 kind/docs:
   - changed-files:
+      - any-glob-to-any-file: "README.md"
       - any-glob-to-any-file: "docs/**"
-      - any-glob-to-any-file: "**/*.md"
 
 kind/go:
   - changed-files:
@@ -16,6 +33,22 @@ kind/just:
   - changed-files:
       - any-glob-to-any-file: "**/justfile"
       - any-glob-to-any-file: "**/*.just"
+
+kind/policy:
+  - changed-files:
+      - any-glob-to-any-file: "AI_POLICY.md"
+      - any-glob-to-any-file: "CODE_OF_CONDUCT.md"
+      - any-glob-to-any-file: "LICENSE"
+
+kind/toolchain:
+  - changed-files:
+      - any-glob-to-any-file: ".mise.toml"
+      - any-glob-to-any-file: ".golangci.yml"
+      - any-glob-to-any-file: ".goreleaser.yaml"
+      - any-glob-to-any-file: "codecov.yml"
+      - any-glob-to-any-file: ".github/codecov.yml"
+      - any-glob-to-any-file: ".coverignore"
+      - any-glob-to-any-file: ".github/dependabot.yml"
 
 kind/yaml:
   - changed-files:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,22 @@ conventions, and the pull request workflow — all of which apply to agents
 exactly as they apply to people. This file carries only what is specific to
 agents.
 
+## Running tools
+
+Invoke tools through `mise`, not from your path:
+
+```bash
+mise exec -- just test
+```
+
+`mise` is active in a person's shell and supplies the versions `.mise.toml`
+declares. An agent's shell has no activation, so a bare `just` resolves to
+whatever is installed globally — usually an older version.
+
+The symptom is a check that fails here and passes in continuous integration, on
+a file nobody edited. When that happens, establish which version ran before
+treating the failure as real.
+
 ## Where the rules come from
 
 Repository layout and shared tooling are specified in


### PR DESCRIPTION
Applies `specify-pull-request-labels`.

Labels now describe what this repository holds, by **purpose** as well as format.

## By purpose

| Label | Matches |
| --- | --- |
| `kind/agents` | `AGENTS.md`, `CLAUDE.md`, `.claude/**` |
| `kind/contributing` | `CONTRIBUTING.md` |
| `kind/policy` | `AI_POLICY.md`, `CODE_OF_CONDUCT.md`, `LICENSE` |
| `kind/toolchain` | `.mise.toml`, `.golangci.yml`, `.goreleaser.yaml`, `codecov.yml`, `.coverignore`, `dependabot.yml` |
| `kind/deps` | `go.mod`, `go.sum`, `package.json`, `bun.lock` |

`kind/docs` previously matched every `.md` in the repository, so a change to agent guidance and a change to reference documentation carried the same label. It is now `README.md` and `docs/**`.

## Also fixed

- `kind/just` added — justfiles were never labelled
- `github/action` → `kind/action`, so every label shares a prefix
- `kind/yaml` no longer overlaps `kind/action`
- Labels matching nothing here removed
- `LICENSE`, `.mise.toml`, and `.coverignore` were matched by nothing — no extension for a format label to catch
- `go.mod`/`go.sum` were unlabelled, so every Dependabot pull request arrived without a label

🤖 Generated with [Claude Code](https://claude.com/claude-code)