### PR TITLE
chore: install the mocking library go.mod declares

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,4 +43,5 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 ## Task tracking
 
 Implementation planning and execution uses the superpowers plugin workflows
-(`writing-plans` and `executing-plans`). Plans live in `docs/plans/`.
+(`writing-plans` and `executing-plans`). Plans live in `docs/plans/`, created
+when the first plan is written.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,7 +136,7 @@ module — change both together.
   (success, error codes, transport failures, nil responses) belong as rows in a
   single table — never split into separate `TestFoo`, `TestFooError`,
   `TestFooNilResponse` methods.
-- Use `golang/mock` for mocking interfaces.
+- Use `go.uber.org/mock` for mocking interfaces.
 
 ## Before committing
 

--- a/justfile
+++ b/justfile
@@ -25,7 +25,7 @@ fetch:
 # Install all dependencies
 deps:
     just go-deps
-    go get -tool github.com/golang/mock/mockgen
+    go get -tool go.uber.org/mock/mockgen
 
 # Run all tests
 test:


### PR DESCRIPTION
Part of `correct-documentation-drift`.

The `deps` recipe installed `github.com/golang/mock/mockgen` — deprecated, and not what the module uses. `go.mod` declares `go.uber.org/mock/mockgen` as a tool. `CONTRIBUTING.md` named the deprecated library too, and `AGENTS.md` pointed at a `docs/plans/` directory that does not exist yet.

`just test` passes at 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)