### PR TITLE
docs: index the documentation directory

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,12 @@
+# Documentation
+
+Reference documentation for the `server` package. Runnable programs live in
+[`examples/`](../examples); contributor setup and conventions are in
+[CONTRIBUTING.md](../CONTRIBUTING.md).
+
+| Document                                           | Covers                                       |
+| -------------------------------------------------- | -------------------------------------------- |
+| [server/README.md](server/README.md)               | Package overview and quick start             |
+| [server/configuration.md](server/configuration.md) | Options, JetStream, and authentication modes |
+| [server/lifecycle.md](server/lifecycle.md)         | Starting, readiness, and shutdown            |
+| [server/logging.md](server/logging.md)             | slog integration and log levels              |


### PR DESCRIPTION
Implements `specify-documentation-homes` task 2.x.

> **WHEN** a reader opens `docs/`
> **THEN** an index tells them what each directory and document covers, rather than requiring them to open each one

Adds `docs/README.md` listing what is there and what each part covers, with a pointer to `examples/` for runnable code and `CONTRIBUTING.md` for contributor setup.

Every link verified to resolve; `just md-fmt-check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
