### PR TITLE
docs: state the mock rule once

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,9 +196,6 @@ module — change both together.
 - `export_test.go` exposes unexported symbols to external tests, by alias or by
   setter. Do not use an alias to re-cover behavior the caller's own test already
   reaches; a helper with its own contract is what the pattern is for.
-- Mocks are generated with `go.uber.org/mock` and committed, never hand-written.
-  A double that carries a real implementation — signing with a real key, serving
-  real HTTP — is not a mock and does not need generating.
 
 External tests in this repository live in `package server_test`, and tables
 carry `validateFunc` callbacks.


### PR DESCRIPTION
Removes a duplication introduced by the previous PR.

`### Test doubles` under `Code standards` and the `### Test file conventions` list under `Testing` both stated that mocks are generated and never hand-written. `repo-standards` requires a fact to be stated in exactly one file — stating it twice **in** one file is the same defect wearing a different hat.

`Test doubles` keeps it, since that is where the layout, the `//go:generate` directive, and the three exceptions already live. The bullet under `Test file conventions` is removed.

Found while double-checking that the convention had actually landed in every repository.

Both shared blocks still hash identically across all five Go repositories.

Docs only. `just md-fmt-check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)