### PR TITLE
docs: say where a mock for an unexported interface goes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,6 +149,22 @@ checkout runs the version `go.mod` records. Destination files end in `.gen.go`
 and are committed. Do not use `gen/` for mocks — that name is taken by API code
 generation.
 
+When the interface is **unexported**, a sibling package cannot work: the mock
+has to import the package to name the types in the interface, and the package's
+own tests have to import the mock. Generate it into the package instead, with a
+destination scoped to tests so the mocking library stays out of the dependency
+graph of anything that imports the package:
+
+```go
+// generate.go, in the package that declares the interface
+package thispackage
+
+//go:generate go tool go.uber.org/mock/mockgen -source=thing.go -destination=thing.gen_test.go -package=thispackage
+```
+
+Either way the directives live in a `generate.go` that holds no code, and the
+generated file carries `.gen` so a reader knows not to edit it.
+
 Where call sites would otherwise repeat the same expectations, write a
 constructor returning a configured mock rather than introducing a hand-written
 type. The generated mock is still what satisfies the interface.


### PR DESCRIPTION
Implements `rescope-go-code-standards` task 5.4a. The rule landed in osapi-io/specs#98.

The `Test doubles` section said generated mocks live in a sibling `mocks` package. For an **unexported** interface that is impossible, and the compiler proves it:

```
imports .../pkg/orchestrator/mocks from orchestrator_test.go
imports .../pkg/orchestrator from renderer.gen.go: import cycle not allowed in test
```

The mock has to import the package to name the types in the interface; the package's own tests have to import the mock.

## What is added

The second case, with its destination scoped to tests:

```go
// generate.go, in the package that declares the interface
package thispackage

//go:generate go tool go.uber.org/mock/mockgen -source=thing.go -destination=thing.gen_test.go -package=thispackage
```

Scoping is load-bearing rather than tidiness — an unscoped mock puts `go.uber.org/mock` into the dependency graph of everything that imports the package.

Either way the directives live in a `generate.go` holding no code, and the generated file carries `.gen` so a reader knows not to edit it.

The section hashes identically in all five Go repositories.

Docs only. `just md-fmt-check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)