### PR TITLE
test: name the exception the log handler double relies on

### DIFF
--- a/pkg/server/logger_test.go
+++ b/pkg/server/logger_test.go
@@ -28,6 +28,9 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+// testHandler is a slog.Handler recording the records written to it. It is
+// hand-written rather than generated because slog.Handler is a standard
+// library interface, which does not change when this package does.
 type testHandler struct {
 	records []slog.Record
 }


### PR DESCRIPTION
Closes the verification for `rescope-go-code-standards` task 5.9 in this repository.

`testHandler` stands in for `slog.Handler` — a standard library interface, which the capability exempts from generation because it does not change when our code does.

Every other hand-written double across the five Go repositories says what it satisfies:

- `errorConn` — *"is a net.Conn that always returns an error on Read"*
- `errorDir` — *"is an fs.File that is a directory but returns an error on ReadDir"*
- `failWriter` — *"is a writer that always returns an error on Write"*

This one did not, so it read as an unexplained exception rather than a named one. One comment, no behavior change.

`just test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)